### PR TITLE
AVRO-2477 - Expose both codec and schema from AvroDataIOReader

### DIFF
--- a/lang/php/lib/avro/data_file.php
+++ b/lang/php/lib/avro/data_file.php
@@ -283,6 +283,22 @@ class AvroDataIOReader
                                                      $this->decoder);
     $this->sync_marker = $this->read(AvroDataIO::SYNC_SIZE);
   }
+  
+  /**
+   * @returns compression codec.
+   */
+  public function getCodec()
+  {
+    return $this->codec;
+  }
+
+  /**
+   * @returns schema attribute json string.
+   */
+  public function getSchema()
+  {
+    return $this->metadata[AvroDataIO::METADATA_SCHEMA_ATTR];
+  }
 
   /**
    * @internal Would be nice to implement data() as an iterator, I think


### PR DESCRIPTION
metadata attribute has been passed to private scope, so codec and schema are no more accessible from outside

Make sure you have checked _all_ steps below.

### Jira

https://issues.apache.org/jira/browse/AVRO-2477

### Tests

I need help to implement unit tests.

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

I don't know where I can add documentation elements